### PR TITLE
Add initial Evernote CLI with auth and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # evernote-cli
-A CLI tool for interacting with Evernote
+
+A CLI tool for interacting with Evernote. Currently supports authentication and searching notes.
+
+## Authentication
+
+Before using other commands you must authenticate. Set the environment variables `EVERNOTE_CLIENT_ID` and `EVERNOTE_CLIENT_SECRET` with your developer credentials and run:
+
+```bash
+evernote-cli auth
+```
+
+This will open a browser window to authenticate with Evernote. When finished, an access token is stored in `~/.config/evernote/auth.json`.
+
+## Searching
+
+Search notes with:
+
+```bash
+evernote-cli search "your query"
+```
+
+Use `--json` to output the raw JSON returned by the API.
+

--- a/README.md
+++ b/README.md
@@ -2,15 +2,19 @@
 
 A CLI tool for interacting with Evernote. Currently supports authentication and searching notes.
 
+## Initial Setup
+
+Run `evernote-cli init` to store your Evernote developer credentials. You will be prompted for your client ID and secret which are saved to `~/.config/evernote/auth.json`.
+
 ## Authentication
 
-Before using other commands you must authenticate. Set the environment variables `EVERNOTE_CLIENT_ID` and `EVERNOTE_CLIENT_SECRET` with your developer credentials and run:
+Once initialized, obtain an OAuth token with:
 
 ```bash
 evernote-cli auth
 ```
 
-This will open a browser window to authenticate with Evernote. When finished, an access token is stored in `~/.config/evernote/auth.json`.
+This opens a browser window to authenticate with Evernote. The access token is saved alongside your credentials in `~/.config/evernote/auth.json`.
 
 ## Searching
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,7 @@ A CLI tool for interacting with Evernote. Currently supports authentication and 
 
 ## Initial Setup
 
-Run `evernote-cli init` to store your Evernote developer credentials. You will be prompted for your client ID and secret which are saved to `~/.config/evernote/auth.json`.
-
-## Authentication
-
-Once initialized, obtain an OAuth token with:
-
-```bash
-evernote-cli auth
-```
-
-This opens a browser window to authenticate with Evernote. The access token is saved alongside your credentials in `~/.config/evernote/auth.json`.
+Run `evernote-cli init` and follow the prompts to provide your Evernote developer client ID and secret. The command then opens a browser to authenticate and stores the resulting token together with your credentials in `~/.config/evernote/auth.json`.
 
 ## Searching
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+)
+
+// Evernote's OAuth2 endpoints would go here. These are placeholders.
+var evernoteEndpoint = oauth2.Endpoint{
+	AuthURL:  "https://www.evernote.com/oauth2/authorize",
+	TokenURL: "https://www.evernote.com/oauth2/token",
+}
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Authenticate with Evernote",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		clientID := os.Getenv("EVERNOTE_CLIENT_ID")
+		clientSecret := os.Getenv("EVERNOTE_CLIENT_SECRET")
+		if clientID == "" || clientSecret == "" {
+			return fmt.Errorf("EVERNOTE_CLIENT_ID and EVERNOTE_CLIENT_SECRET must be set")
+		}
+
+		ctx := context.Background()
+		conf := &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Scopes:       []string{"basic"},
+			Endpoint:     evernoteEndpoint,
+			RedirectURL:  "http://localhost:8080/callback",
+		}
+
+		// Start a local server to receive the callback
+		srv := &http.Server{Addr: ":8080"}
+		codeCh := make(chan string)
+		http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+			code := r.URL.Query().Get("code")
+			fmt.Fprintf(w, "Authentication complete. You can close this window.")
+			codeCh <- code
+		})
+		go func() {
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Fatalf("server error: %v", err)
+			}
+		}()
+
+		url := conf.AuthCodeURL("state", oauth2.AccessTypeOffline)
+		// Open browser if possible
+		exec.Command("xdg-open", url).Start()
+		fmt.Printf("If the browser did not open, visit: %s\n", url)
+
+		code := <-codeCh
+		srv.Shutdown(ctx)
+
+		token, err := conf.Exchange(ctx, code)
+		if err != nil {
+			return fmt.Errorf("token exchange failed: %w", err)
+		}
+
+		tokenData, err := json.Marshal(token)
+		if err != nil {
+			return err
+		}
+		configDir := os.Getenv("HOME") + "/.config/evernote"
+		os.MkdirAll(configDir, 0700)
+		if err := os.WriteFile(configDir+"/auth.json", tokenData, 0600); err != nil {
+			return err
+		}
+		fmt.Println("Authentication successful. Token saved.")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(authCmd)
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,7 +10,7 @@ import (
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Store Evernote client credentials",
+	Short: "Initialize credentials and authenticate",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		reader := bufio.NewReader(cmd.InOrStdin())
 		fmt.Fprint(cmd.OutOrStdout(), "Evernote Client ID: ")
@@ -27,13 +27,15 @@ var initCmd = &cobra.Command{
 		secret = strings.TrimSpace(secret)
 
 		cfg := &Config{ClientID: id, ClientSecret: secret}
-		if existing, err := loadConfig(); err == nil && existing.Token != nil {
-			cfg.Token = existing.Token
+		token, err := runAuthFlow(id, secret)
+		if err != nil {
+			return err
 		}
+		cfg.Token = token
 		if err := saveConfig(cfg); err != nil {
 			return err
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "Configuration saved to", configPath)
+		fmt.Fprintln(cmd.OutOrStdout(), "Authentication successful. Configuration saved to", configPath)
 		return nil
 	},
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Store Evernote client credentials",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reader := bufio.NewReader(cmd.InOrStdin())
+		fmt.Fprint(cmd.OutOrStdout(), "Evernote Client ID: ")
+		id, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(cmd.OutOrStdout(), "Evernote Client Secret: ")
+		secret, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		id = strings.TrimSpace(id)
+		secret = strings.TrimSpace(secret)
+
+		cfg := &Config{ClientID: id, ClientSecret: secret}
+		if existing, err := loadConfig(); err == nil && existing.Token != nil {
+			cfg.Token = existing.Token
+		}
+		if err := saveConfig(cfg); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "Configuration saved to", configPath)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,45 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
 )
 
 // jsonFlag is used by subcommands to output JSON.
 var jsonFlag bool
+var configPath = filepath.Join(os.Getenv("HOME"), ".config", "evernote", "auth.json")
+
+type Config struct {
+	ClientID     string        `json:"client_id"`
+	ClientSecret string        `json:"client_secret"`
+	Token        *oauth2.Token `json:"token,omitempty"`
+}
+
+func loadConfig() (*Config, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func saveConfig(c *Config) error {
+	os.MkdirAll(filepath.Dir(configPath), 0700)
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, data, 0600)
+}
 
 // rootCmd is the main command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -26,10 +57,12 @@ func init() {
 }
 
 func checkAuth() (string, error) {
-	configPath := os.Getenv("HOME") + "/.config/evernote/auth.json"
-	data, err := os.ReadFile(configPath)
+	cfg, err := loadConfig()
 	if err != nil {
-		return "", fmt.Errorf("could not read auth token: %w", err)
+		return "", fmt.Errorf("could not read config: %w", err)
 	}
-	return string(data), nil
+	if cfg.Token == nil || !cfg.Token.Valid() {
+		return "", fmt.Errorf("no valid token found, run 'evernote-cli auth'")
+	}
+	return cfg.Token.AccessToken, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// jsonFlag is used by subcommands to output JSON.
+var jsonFlag bool
+
+// rootCmd is the main command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "evernote-cli",
+	Short: "A CLI tool to interact with Evernote",
+}
+
+// Execute executes the root command.
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.PersistentFlags().BoolVar(&jsonFlag, "json", false, "output in JSON format")
+}
+
+func checkAuth() (string, error) {
+	configPath := os.Getenv("HOME") + "/.config/evernote/auth.json"
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", fmt.Errorf("could not read auth token: %w", err)
+	}
+	return string(data), nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,7 +62,7 @@ func checkAuth() (string, error) {
 		return "", fmt.Errorf("could not read config: %w", err)
 	}
 	if cfg.Token == nil || !cfg.Token.Valid() {
-		return "", fmt.Errorf("no valid token found, run 'evernote-cli auth'")
+		return "", fmt.Errorf("no valid token found, run 'evernote-cli init'")
 	}
 	return cfg.Token.AccessToken, nil
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+)
+
+var searchCmd = &cobra.Command{
+	Use:   "search [query]",
+	Short: "Search notes",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		token, err := checkAuth()
+		if err != nil {
+			return err
+		}
+		q := url.QueryEscape(args[0])
+		req, err := http.NewRequest("GET", "https://api.evernote.com/v1/search?query="+q, nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status: %s", resp.Status)
+		}
+
+		var data interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return err
+		}
+
+		if jsonFlag {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(data)
+		}
+
+		// naive formatting
+		bytes, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", string(bytes))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(searchCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/example/evernote-cli
+module github.com/cloudmanic/evernote-cli
 
 go 1.24.3
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/example/evernote-cli
+
+go 1.24.3
+
+require (
+	github.com/spf13/cobra v1.9.1
+	golang.org/x/oauth2 v0.30.0
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/example/evernote-cli/cmd"
+import "github.com/cloudmanic/evernote-cli/cmd"
 
 func main() {
 	if err := cmd.Execute(); err != nil {

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/example/evernote-cli/cmd"
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## Summary
- initialize Go module
- add CLI structure using cobra
- implement `auth` command for OAuth and saving token to `~/.config/evernote/auth.json`
- implement `search` command that hits Evernote API and supports `--json` flag
- update README with basic usage instructions

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686ac6df1bc4832f9f75876256133727