### PR TITLE
Add version command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           fi
           
           echo "Building for $GOOS/$GOARCH..."
-          GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-s -w" -o "dist/${output_name}" .
+          GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-s -w -X github.com/cloudmanic/evernote-cli/cmd.Version=${{ steps.version.outputs.version }}" -o "dist/${output_name}" .
           
           # Create compressed archives for easier distribution
           if [ "$GOOS" = "windows" ]; then

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 
 ## build: Build the binary for the current platform
 build:
-	go build -o $(BINARY_NAME) .
+	go build -ldflags="-X github.com/cloudmanic/evernote-cli/cmd.Version=$(VERSION)" -o $(BINARY_NAME) .
 
 ## install: Build and install the binary to GOPATH/bin
 install:
-	go install .
+	go install -ldflags="-X github.com/cloudmanic/evernote-cli/cmd.Version=$(VERSION)" .
 
 ## test: Run all tests
 test:
@@ -52,12 +52,12 @@ clean:
 
 ## cross-build: Build for all release platforms
 cross-build: clean
-	GOOS=linux   GOARCH=amd64 go build -o $(BINARY_NAME)-linux-amd64 .
-	GOOS=linux   GOARCH=arm64 go build -o $(BINARY_NAME)-linux-arm64 .
-	GOOS=darwin  GOARCH=amd64 go build -o $(BINARY_NAME)-darwin-amd64 .
-	GOOS=darwin  GOARCH=arm64 go build -o $(BINARY_NAME)-darwin-arm64 .
-	GOOS=windows GOARCH=amd64 go build -o $(BINARY_NAME)-windows-amd64.exe .
-	GOOS=windows GOARCH=arm64 go build -o $(BINARY_NAME)-windows-arm64.exe .
+	GOOS=linux   GOARCH=amd64 go build -ldflags="-X github.com/cloudmanic/evernote-cli/cmd.Version=$(VERSION)" -o $(BINARY_NAME)-linux-amd64 .
+	GOOS=linux   GOARCH=arm64 go build -ldflags="-X github.com/cloudmanic/evernote-cli/cmd.Version=$(VERSION)" -o $(BINARY_NAME)-linux-arm64 .
+	GOOS=darwin  GOARCH=amd64 go build -ldflags="-X github.com/cloudmanic/evernote-cli/cmd.Version=$(VERSION)" -o $(BINARY_NAME)-darwin-amd64 .
+	GOOS=darwin  GOARCH=arm64 go build -ldflags="-X github.com/cloudmanic/evernote-cli/cmd.Version=$(VERSION)" -o $(BINARY_NAME)-darwin-arm64 .
+	GOOS=windows GOARCH=amd64 go build -ldflags="-X github.com/cloudmanic/evernote-cli/cmd.Version=$(VERSION)" -o $(BINARY_NAME)-windows-amd64.exe .
+	GOOS=windows GOARCH=arm64 go build -ldflags="-X github.com/cloudmanic/evernote-cli/cmd.Version=$(VERSION)" -o $(BINARY_NAME)-windows-arm64.exe .
 
 ## help: Show this help message
 help:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,9 @@ import (
 
 // jsonFlag is used by subcommands to output JSON.
 var jsonFlag bool
+
+// Version is set at build time via -ldflags. Defaults to "dev" for local builds.
+var Version = "dev"
 var configPath = filepath.Join(os.Getenv("HOME"), ".config", "evernote", "auth.json")
 
 // Config holds the Evernote API credentials and auth token.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,24 @@
+// Copyright 2026. All rights reserved.
+// Date: 2026-02-06
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd prints the current version of the CLI.
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of evernote-cli",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintf(cmd.OutOrStdout(), "evernote-cli version %s\n", Version)
+		return nil
+	},
+}
+
+// init registers the version command with the root command.
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026. All rights reserved.
+// Date: 2026-02-06
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCommand(t *testing.T) {
+	t.Run("prints default dev version", func(t *testing.T) {
+		original := Version
+		Version = "dev"
+		defer func() { Version = original }()
+
+		var buf bytes.Buffer
+		versionCmd.SetOut(&buf)
+		err := versionCmd.RunE(versionCmd, []string{})
+		require.NoError(t, err)
+
+		assert.Equal(t, "evernote-cli version dev\n", buf.String())
+	})
+
+	t.Run("prints injected version", func(t *testing.T) {
+		original := Version
+		Version = "20260209130350-5179b6b"
+		defer func() { Version = original }()
+
+		var buf bytes.Buffer
+		versionCmd.SetOut(&buf)
+		err := versionCmd.RunE(versionCmd, []string{})
+		require.NoError(t, err)
+
+		assert.Equal(t, "evernote-cli version 20260209130350-5179b6b\n", buf.String())
+	})
+}
+
+func TestVersionCmdConfiguration(t *testing.T) {
+	assert.Equal(t, "version", versionCmd.Use)
+	assert.Equal(t, "Print the version of evernote-cli", versionCmd.Short)
+	assert.NotNil(t, versionCmd.RunE)
+}
+
+func TestVersionCmdRegistration(t *testing.T) {
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "version" {
+			found = true
+			assert.Equal(t, "Print the version of evernote-cli", c.Short)
+			break
+		}
+	}
+	assert.True(t, found, "version command should be registered")
+}


### PR DESCRIPTION
## Summary
- Adds a `version` subcommand that prints the CLI version (e.g. `evernote-cli version`)
- Version is injected at build time via `-ldflags` and defaults to `dev` for local builds
- Updated Makefile `build`, `install`, and `cross-build` targets to inject version
- Updated GitHub Actions release workflow to inject the release version into binaries

## Test plan
- [x] All existing tests pass
- [x] New tests for version command (default version, injected version, registration)
- [x] Verified `evernote-cli version` outputs `dev` for local builds
- [x] Verified ldflags injection produces correct version string